### PR TITLE
Ensure brush tool is active at launch

### DIFF
--- a/pixel_drawing/utils/icon_effects.py
+++ b/pixel_drawing/utils/icon_effects.py
@@ -88,21 +88,23 @@ def create_icon_with_states(svg_path: str, size: int = 24) -> Optional[QIcon]:
         renderer.render(painter)
         painter.end()
         
-        # Add normal state
+        # Add normal state - use dark icon when unchecked
         icon.addPixmap(normal_pixmap, QIcon.Mode.Normal, QIcon.State.Off)
-        icon.addPixmap(normal_pixmap, QIcon.Mode.Normal, QIcon.State.On)
-        
-        # Create selected state (white icon)
+
+        # When the button is checked Qt requests the Normal/On pixmap.
+        # Provide the white variant here so the icon color updates
+        # immediately when a tool button is toggled on startup.
         selected_pixmap = QPixmap(size, size)
+        icon.addPixmap(selected_pixmap, QIcon.Mode.Normal, QIcon.State.On)
+
+        # Now render the white icon used for both Normal/On and Selected states
         selected_pixmap.fill(Qt.GlobalColor.transparent)
-        
         painter = QPainter(selected_pixmap)
-        # First draw the original icon
         renderer.render(painter)
-        # Then overlay white color using composition mode
         painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceIn)
         painter.fillRect(selected_pixmap.rect(), QColor(255, 255, 255))
         painter.end()
+        # Create selected state (white icon) for explicit Selected/Active modes
         
         # Add selected states  
         icon.addPixmap(selected_pixmap, QIcon.Mode.Selected, QIcon.State.Off)

--- a/pixel_drawing/views/app.py
+++ b/pixel_drawing/views/app.py
@@ -1,0 +1,3 @@
+from .main_window import PixelDrawingApp
+
+__all__ = ["PixelDrawingApp"]

--- a/pixel_drawing/views/main_window.py
+++ b/pixel_drawing/views/main_window.py
@@ -348,8 +348,12 @@ class PixelDrawingApp(QMainWindow):
             row = i // 2
             col = i % 2
             tools_layout.addWidget(btn, row, col)
-        
+
         side_layout.addWidget(tools_group)
+
+        # Ensure the default brush tool is active and the canvas is ready
+        # for drawing immediately on application startup.
+        self.set_tool(ToolType.BRUSH.value)
         
         # Color group
         self.create_color_panel(side_layout)


### PR DESCRIPTION
## Summary
- fix icon state so checked tool icons draw in white
- select brush tool automatically when building side panel
- expose `PixelDrawingApp` in a new `views/app.py` shim for tests

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/ui/views/test_app_window.py::TestAppWindowInitialization::test_app_window_default_initialization -q`
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: side panel and canvas tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f725a69cc832fb23055e8a17a4c96